### PR TITLE
Fix test error: "babelHelpers is not defined"

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -21,6 +21,7 @@
   "plugins": [
     "babel-plugin-transform-class-properties",
     "transform-object-rest-spread",
-    "external-helpers"
+    "external-helpers",
+    "transform-runtime"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "eslint": "^4.14.0",

--- a/script/demoConfig.js
+++ b/script/demoConfig.js
@@ -15,6 +15,7 @@ const inputOptions = {
   plugins: [
     babel({
       exclude: ['node_modules/**'],
+      runtimeHelpers: true,
     }),
     resolve({
       jsnext: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -883,6 +883,13 @@ babel-plugin-transform-regenerator@^6.22.0:
   dependencies:
     regenerator-transform "^0.10.0"
 
+babel-plugin-transform-runtime@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
+  integrity sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-strict-mode@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"


### PR DESCRIPTION
- (Initial) command `yarn start` works well on `master`, but `yarn test` failed for error `ReferenceError: babelHelpers is not defined`.

Regarding to [this thread](https://github.com/babel/babel/issues/9366#issuecomment-455748788):
> This is because you're using '@babel/plugin-external-helpers', in your plugin list. If you do that, it is up to you to load the helpers. '@babel/plugin-transform-runtime', already loads an alternative approach for helpers, so I would just remove the external helpers plugin.

First step is install new package `@babel/plugin-transform-runtime` but it will lead to another failure `Error: Cannot find module '@babel/core'` where it tries to find the latest `babel@7` however we are using `babel@6`.
Hence, we are installing a legacy version of that package [`[babel-plugin-transform-runtime]`](https://www.npmjs.com/package/babel-plugin-transform-runtime) to achieve the original purpose.

- The command `yarn test` works well now! 
- But `yarn start` failed for error:
> Error: Runtime helpers are not enabled. Either exclude the transform-runtime Babel plugin or pass the `runtimeHelpers: true` option. See https://github.com/rollup/rollup-plugin-babel#configuring-babel for more information

Then we found [this](https://github.com/rollup/rollup-plugin-babel#helpers), where it says
> Alternatively, if you know what you're doing, you can use the transform-runtime plugin. If you do this, use runtimeHelpers: true:

```jsx
rollup.rollup({
  ...,
  plugins: [
    babel({ runtimeHelpers: true })
  ]
}).then(...)
```

That's it! Then everything works well now.