### PR TITLE
Add Coveralls test in CI

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,1 @@
-repo_token: NBBogLRBjDmDHFXdTpyvlqLpSDjvVxoFZ
+repo_token: 9SB6zCIanuu5JSF6EK99YF4LkdOoQOxkZ

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,1 @@
-repo_token: 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
+repo_token: NBBogLRBjDmDHFXdTpyvlqLpSDjvVxoFZ

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+repo_token: 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

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,17 @@
+name: pr
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "12.14.0"
+      - run: yarn install
+      - run: yarn test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,3 +15,6 @@ jobs:
           node-version: "12.14.0"
       - run: yarn install
       - run: yarn test
+      - uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "publish-demo": "yarn build-demo && node script/publishGhpage.js",
     "deploy": "gh-pages -d static",
     "lint": "eslint ./",
-    "test": "jest --no-cache",
+    "test": "jest --coverage",
     "precommit": "lint-staged"
   },
   "repository": {


### PR DESCRIPTION
As title

Steps:
1.  Use `jest --coverage` to generate coverage report in [CI step](https://github.com/marilyn79218/react-lazy-show/pull/15/files#diff-15c806aa509538190832852f439e9921a23bec2da81f95ed0e4bf13c14e5b160R17).
2. Add this repo to [Coveralls](https://coveralls.io/repos/new). See screenshot-1.
3. Will see instruction when you click on the `details` button in screenshot-1, and it redirect to screenshot-2 where it says you should add `.coveralls.yml` for it.
4. ~~Generate Github [perosnal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) at [Github page](https://github.com/settings/tokens).~~ Use your repo token shown in [coveralls page](https://coveralls.io/builds/39104316) (e.g., `https://coveralls.io/builds/<build_id>`). See the token shown in screenshot-2.
5. Add the token just generated in the `.coveralls.yml`.
6. Push your changes to Github that triggers `test` and `coverage/coveralls ` CI checks.
7. Coverage data is passed to coveralls page as shown in screenshot-3.

Sidenotes:
- When you click on `Documentation` button in screenshot-2 (at page bottom), you will be redirected to [screenshot-4 (Coveralls getting started page)](https://docs.coveralls.io/).

| Number | Screenshots |
| ------ | ----- |
| 1 | ![image](https://user-images.githubusercontent.com/22482071/115982565-c9a7de80-a5ce-11eb-9a20-25d8fbaeaa8e.png) |
| 2 | ![image](https://user-images.githubusercontent.com/22482071/116840662-42c7b700-ac09-11eb-8ca0-199891f1f242.png) |
| 3 | ![image](https://user-images.githubusercontent.com/22482071/115982996-48058000-a5d1-11eb-84ad-0b05c25c073b.png) |
| 4 | ![image](https://user-images.githubusercontent.com/22482071/116840408-44dd4600-ac08-11eb-858f-b9c31eb1fdc7.png) |
