### PR TITLE
feat: playing upload & download actions

### DIFF
--- a/.github/workflows/download-cross-workflow.js
+++ b/.github/workflows/download-cross-workflow.js
@@ -5,12 +5,10 @@ const path = require("path");
 const actifactFolderPath = path.join(process.cwd());
 fs.readdirSync(actifactFolderPath, "utf-8").forEach(file => {
   if (file.endsWith(".txt")) {
-    console.log("file", file);
-
     const rawFileData = fs.readFileSync(path.join(actifactFolderPath, file), "utf-8");
-    console.log("rawFileData", rawFileData);
-
     const fileData = JSON.parse(rawFileData);
-    console.log("fileData: ", fileData);
+
+    console.log(fileData);
+    console.log(Array.isArray(fileData), fileData[0], fileData[1], fileData[2]);
   }
 });

--- a/.github/workflows/download-cross-workflow.js
+++ b/.github/workflows/download-cross-workflow.js
@@ -1,0 +1,16 @@
+// @noflow
+const fs = require("fs");
+const path = require("path");
+
+const actifactFolderPath = path.join(process.cwd());
+fs.readdirSync(actifactFolderPath, "utf-8").forEach(file => {
+  if (file.endsWith(".txt")) {
+    // console.log("file", file);
+
+    const rawFileData = fs.readFileSync(path.join(actifactFolderPath, file), "utf-8");
+    console.log("rawFileData", rawFileData);
+
+    // const fileData = JSON.parse(rawFileData);
+    // console.log("fileData: ", fileData);
+  }
+});

--- a/.github/workflows/download-cross-workflow.js
+++ b/.github/workflows/download-cross-workflow.js
@@ -5,12 +5,12 @@ const path = require("path");
 const actifactFolderPath = path.join(process.cwd());
 fs.readdirSync(actifactFolderPath, "utf-8").forEach(file => {
   if (file.endsWith(".txt")) {
-    // console.log("file", file);
+    console.log("file", file);
 
     const rawFileData = fs.readFileSync(path.join(actifactFolderPath, file), "utf-8");
     console.log("rawFileData", rawFileData);
 
-    // const fileData = JSON.parse(rawFileData);
-    // console.log("fileData: ", fileData);
+    const fileData = JSON.parse(rawFileData);
+    console.log("fileData: ", fileData);
   }
 });

--- a/.github/workflows/download-cross-workflow.yml
+++ b/.github/workflows/download-cross-workflow.yml
@@ -20,9 +20,12 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
+          name: generated-data-2.txt
           path: downloads
       - name: Download artifact
         uses: actions/download-artifact@v2
+        with:
+          name: generated-data-2.txt
       - name: Collect data
         id: collect_data
         run: echo "::set-output name=downloadedData::$(node ./.github/workflows/download-cross-workflow.js)"

--- a/.github/workflows/download-cross-workflow.yml
+++ b/.github/workflows/download-cross-workflow.yml
@@ -20,12 +20,9 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: generated-data-2.txt
           path: downloads
       - name: Download artifact
         uses: actions/download-artifact@v2
-        with:
-          name: generated-data-2.txt
       - name: Collect data
         id: collect_data
         run: echo "::set-output name=downloadedData::$(node ./.github/workflows/download-cross-workflow.js)"

--- a/.github/workflows/download-cross-workflow.yml
+++ b/.github/workflows/download-cross-workflow.yml
@@ -1,0 +1,33 @@
+name: download-cross-workflow
+
+on:
+  push
+
+jobs:
+  download-cross-workflow:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Generate data
+        id: generate_data
+        run: echo "::set-output name=generatedData::$(node ./.github/workflows/generate-data.js)"
+      - name: Write to file
+        run: |
+          mkdir downloads
+          cd downloads
+          echo "generatedData is ${{ steps.generate_data.outputs.generatedData }}"
+          echo "${{ steps.generate_data.outputs.generatedData }}" > generated-data-1.txt
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: generated-data-2.txt
+          path: downloads
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: generated-data-2.txt
+      - name: Collect data
+        id: collect_data
+        run: echo "::set-output name=downloadedData::$(node ./.github/workflows/download-cross-workflow.js)"
+      - name: Post results to Log console
+        run: echo "The downloaded ramdom number is ${{ steps.collect_data.outputs.downloadedData }}"

--- a/.github/workflows/download-cross-workflow.yml
+++ b/.github/workflows/download-cross-workflow.yml
@@ -10,13 +10,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: Generate data
         id: generate_data
-        run: echo "::set-output name=generatedData::$(node ./.github/workflows/generate-data.js)"
-      - name: Write to file
         run: |
           mkdir downloads
           cd downloads
-          echo "generatedData is ${{ steps.generate_data.outputs.generatedData }}"
-          echo "${{ steps.generate_data.outputs.generatedData }}" > generated-data.txt
+          echo "::set-output name=generatedData::$(node ../.github/workflows/generate-data.js)" > generated-data.txt
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/download-cross-workflow.yml
+++ b/.github/workflows/download-cross-workflow.yml
@@ -13,7 +13,7 @@ jobs:
         run: |
           mkdir downloads
           cd downloads
-          echo "::set-output name=generatedData::$(node ../.github/workflows/generate-data.js)" > generated-data.txt
+          echo "$(node ../.github/workflows/generate-data.js)" > generated-data.txt
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/download-cross-workflow.yml
+++ b/.github/workflows/download-cross-workflow.yml
@@ -16,16 +16,16 @@ jobs:
           mkdir downloads
           cd downloads
           echo "generatedData is ${{ steps.generate_data.outputs.generatedData }}"
-          echo "${{ steps.generate_data.outputs.generatedData }}" > generated-data-1.txt
+          echo "${{ steps.generate_data.outputs.generatedData }}" > generated-data.txt
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: generated-data-2.txt
+          name: data-arctifact
           path: downloads
       - name: Download artifact
         uses: actions/download-artifact@v2
         with:
-          name: generated-data-2.txt
+          name: data-arctifact
       - name: Collect data
         id: collect_data
         run: echo "::set-output name=downloadedData::$(node ./.github/workflows/download-cross-workflow.js)"

--- a/.github/workflows/generate-data.js
+++ b/.github/workflows/generate-data.js
@@ -1,0 +1,7 @@
+
+const data = [];
+for (let i=0; i<3; i++) {
+  data.push(`idx: ${i} - time: ${new Date().toISOString()}`);
+};
+
+console.log(JSON.stringify(data));


### PR DESCRIPTION
This is just a PR to playing around [upload-artifact](https://github.com/actions/upload-artifact) and [download-artifact](https://github.com/actions/download-artifact) locally.

## Things I learned
1. How to (a) execute a node script and (b) write a new file via `echo` at the same time.
```
echo "$(node ../.github/workflows/generate-data.js)" > generated-data.txt
```
2. If the script executed via `echo` doing `console.log()` multiple times, only the first log will be the content of `echo` command.
For example, if there're 3 logs `console.log("content A");`, `console.log("content B");`, `console.log("content C");` in script `generate-data.js`, only `content A` will be write into `generated-data.txt`.
3. The artifact name is not required, but still have to give it a specific name (e.g., `data-arctifact` in this case). See [detail in #20](https://github.com/marilyn79218/react-lazy-show/pull/20/files).

## Code Example
- youtube: https://www.youtube.com/watch?v=Zcsk_Nzv-aU&ab_channel=CameronMcKenzie

## References
**Documents**
- `Storing data as artifact`: https://docs.github.com/en/actions/guides/storing-workflow-data-as-artifacts
- `Workflow commands` (can be used in `echo` command): https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions

**Github Actions**
- `upload-artifact`: https://github.com/actions/upload-artifact
- `download-artifact`: https://github.com/actions/download-artifact