### PR TITLE
feat: upload & download actions without `artifact name`

### DIFF
--- a/.github/workflows/download-cross-workflow.js
+++ b/.github/workflows/download-cross-workflow.js
@@ -13,7 +13,13 @@ const path = require("path");
 
 // Case 1:
 // 綜合 (A) & (B), 我們的 actifact 路徑為 project_root_directory/artifact
-const actifactFolderPath = path.join(process.cwd(), "artifact");
+// const actifactFolderPath = path.join(process.cwd(), "artifact");
+
+// Case 2:
+// 如果今天 "upload-artifact@v2" 有設定 name 為 "uploaded-artifact"
+// 則我們的 actifact 路徑為 project_root_directory/uploaded-artifact
+const actifactFolderPath = path.join(process.cwd(), "uploaded-artifact");
+
 fs.readdirSync(actifactFolderPath, "utf-8").forEach(file => {
   if (file.endsWith(".txt")) {
     const rawFileData = fs.readFileSync(path.join(actifactFolderPath, file), "utf-8");

--- a/.github/workflows/download-cross-workflow.js
+++ b/.github/workflows/download-cross-workflow.js
@@ -12,11 +12,12 @@ const path = require("path");
 // Ref: https://github.com/actions/download-artifact#download-all-artifacts
 
 // Case 1:
-// 綜合 (A) & (B), 我們的 actifact 路徑為 project_root_directory/artifact
+// 當 "upload-artifact@v2" 沒有設定 name，
+// 則綜合 (A) & (B), 我們的 actifact 路徑為 project_root_directory/artifact
 // const actifactFolderPath = path.join(process.cwd(), "artifact");
 
 // Case 2:
-// 如果今天 "upload-artifact@v2" 有設定 name 為 "uploaded-artifact"
+// 如果今天 "upload-artifact@v2" 有設定 name 為 "uploaded-artifact"，
 // 則我們的 actifact 路徑為 project_root_directory/uploaded-artifact
 const actifactFolderPath = path.join(process.cwd(), "uploaded-artifact");
 

--- a/.github/workflows/download-cross-workflow.js
+++ b/.github/workflows/download-cross-workflow.js
@@ -2,7 +2,18 @@
 const fs = require("fs");
 const path = require("path");
 
-const actifactFolderPath = path.join(process.cwd());
+// Background (A) -
+// 如果 "upload-artifact@v2" 沒有設定 param "name"，則預設會使用 "artifact" 當作該 artifact name 做 upload。
+// Ref: ref: https://github.com/actions/upload-artifact#uploading-without-an-artifact-name
+
+// Background (B) -
+// 當 "download-artifact@v2" 沒有設定 param "name"，
+// 每個 artifact 都會分別被 downloaded 至自己專屬的 folder 底下，且該 folder 會被以那個 artifact name 命名。
+// Ref: https://github.com/actions/download-artifact#download-all-artifacts
+
+// Case 1:
+// 綜合 (A) & (B), 我們的 actifact 路徑為 project_root_directory/artifact
+const actifactFolderPath = path.join(process.cwd(), "artifact");
 fs.readdirSync(actifactFolderPath, "utf-8").forEach(file => {
   if (file.endsWith(".txt")) {
     const rawFileData = fs.readFileSync(path.join(actifactFolderPath, file), "utf-8");

--- a/.github/workflows/download-cross-workflow.yml
+++ b/.github/workflows/download-cross-workflow.yml
@@ -22,7 +22,8 @@ jobs:
         uses: actions/download-artifact@v2
       - name: Display structure of downloaded files
         run: ls -R
-        working-directory: .
+        # Can try to set "working-directory" as "." or "./artifact"
+        working-directory: ./artifact
       - name: Collect data
         id: collect_data
         run: echo "::set-output name=downloadedData::$(node ./.github/workflows/download-cross-workflow.js)"

--- a/.github/workflows/download-cross-workflow.yml
+++ b/.github/workflows/download-cross-workflow.yml
@@ -17,12 +17,9 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: data-arctifact
           path: downloads
       - name: Download artifact
         uses: actions/download-artifact@v2
-        with:
-          name: data-arctifact
       - name: Collect data
         id: collect_data
         run: echo "::set-output name=downloadedData::$(node ./.github/workflows/download-cross-workflow.js)"

--- a/.github/workflows/download-cross-workflow.yml
+++ b/.github/workflows/download-cross-workflow.yml
@@ -20,6 +20,9 @@ jobs:
           path: downloads
       - name: Download artifact
         uses: actions/download-artifact@v2
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: .
       - name: Collect data
         id: collect_data
         run: echo "::set-output name=downloadedData::$(node ./.github/workflows/download-cross-workflow.js)"

--- a/.github/workflows/download-cross-workflow.yml
+++ b/.github/workflows/download-cross-workflow.yml
@@ -17,13 +17,14 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
+          name: uploaded-artifact
           path: downloads
       - name: Download artifact
         uses: actions/download-artifact@v2
       - name: Display structure of downloaded files
         run: ls -R
-        # Can try to set "working-directory" as "." or "./artifact"
-        working-directory: ./artifact
+        # Can try to set "working-directory" as "." or `./${name_param_of_upload-artifact@v2}`
+        working-directory: .
       - name: Collect data
         id: collect_data
         run: echo "::set-output name=downloadedData::$(node ./.github/workflows/download-cross-workflow.js)"


### PR DESCRIPTION
Based on #19, but we don't specify the `name` input parameter in both `upload-artifact` & `download-artifact` actions, and see how do this change affect the path of storing artifact. 