### PR TITLE
fix: update trigger event for #23

### DIFF
--- a/.github/workflows/download-cross-workflow.yml
+++ b/.github/workflows/download-cross-workflow.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Get PR number
+        run: echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }'
       - name: Download artifact once PR merged
         uses: dawidd6/action-download-artifact@v2
         with:

--- a/.github/workflows/download-cross-workflow.yml
+++ b/.github/workflows/download-cross-workflow.yml
@@ -2,8 +2,7 @@ name: download-cross-workflow
 
 on:
   pull_request:
-    branches:
-      - feat/pr-upload-data
+    types: [ labeled ]
 
 jobs:
   download-cross-workflow:

--- a/.github/workflows/download-cross-workflow.yml
+++ b/.github/workflows/download-cross-workflow.yml
@@ -1,21 +1,21 @@
 name: download-cross-workflow
 
 on:
-  pull_request:
-    types: [ labeled ]
+  push:
+    branches:
+      - master
 
 jobs:
   download-cross-workflow:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Get PR number
-        run: echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }'
       - name: Download artifact once PR merged
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: pr-upload-data.yml
           name: data-arctifact
+          pr: ${{github.event.pull_request.number}}
       - name: Display structure of downloaded files
         run: ls -R
         working-directory: .


### PR DESCRIPTION
As title, this PR updates the triggering event for `download-cross-workflow` that was initially written in #23.