### PR TITLE
Just a temp commit.

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,1 +1,3 @@
 export const ACTION_NAME = 'REACT_SELECTRONIC_ACTIONS';
+
+const DELETE_ME = "Just a test change to trigger a new upload GH action.";


### PR DESCRIPTION
This PR is simply made for creating a latest timestamp while I'm working on `downloading corresponding PR artifact`.

## (Background) CI behavior table existed in codebase
| Event type | Triggered CI |
| ---------- | ------------- |
| `create PR` | upload artifact (data with current timestamp) |
| `pushed to master` | download CI (**download corresponding PR data**) |

## Test Scenario
Say we have 2 PRs:
- `PR_1st` which has data with timestamp `PR_1st_timestamp` and it's earlier than `PR_2nd_timestamp`.
- `PR_2nd` which has data with timestamp `PR_2nd_timestamp`

When `PR_1st` is merged, I expect the data downloaded by `download CI` should be `PR_1st_timestamp` rather than `PR_2nd_timestamp`.

To know whether it's downloading the data with `PR_1st_timestamp`, I have logged the data it download in [download CI script](https://github.com/marilyn79218/react-lazy-show/blob/master/.github/workflows/download-cross-workflow.js#L11). As screenshotted in below, the logged timestamp should be the earlier one (i.e., `PR_1st_timestamp`).

![image](https://user-images.githubusercontent.com/22482071/120000852-d53f5880-c005-11eb-869e-db947ff1be37.png)

