### PR TITLE
fix: [dependabot write permission] Add PR action that can write comments

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,7 @@ jobs:
       - name: "Writing comments"
         uses: actions/github-script@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const path = require('path');
             const scriptPath = path.resolve('./.github/workflows/writing-comments.js');

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,7 @@ jobs:
       - name: "Writing comments"
         uses: actions/github-script@v4
         with:
-          # github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const path = require('path');
             const scriptPath = path.resolve('./.github/workflows/writing-comments.js');

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,23 @@
+name: pr
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  dependabot-comments:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14.15.4"
+      - name: "Writing comments"
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const path = require('path');
+            const scriptPath = path.resolve('./.github/workflows/writing-comments.js');
+            await require(scriptPath)(github, context, core);

--- a/.github/workflows/writing-comments.js
+++ b/.github/workflows/writing-comments.js
@@ -19,14 +19,15 @@ module.exports = async (github, context, core) => {
       }
     }
 
-    const timestamp = Date.now();
+    const date = new Date();
+    const utcString = date.toUTCString();
     if (!commentId) {
       console.log("Creating comment...");
       await github.issues.createComment({
         issue_number: context.issue.number,
         owner: context.repo.owner,
         repo: context.repo.repo,
-        body: timestamp,
+        body: utcString,
       });
     } else {
       console.log("Updating comment...", commentId);
@@ -34,7 +35,7 @@ module.exports = async (github, context, core) => {
         comment_id: commentId,
         owner: context.repo.owner,
         repo: context.repo.repo,
-        body: timestamp,
+        body: utcString,
       });
     }
   } catch (error) {

--- a/.github/workflows/writing-comments.js
+++ b/.github/workflows/writing-comments.js
@@ -1,0 +1,43 @@
+
+// It's a testing script to test dependabot writing permission
+// Should be removed once the test done.
+module.exports = async (github, context, core) => {
+  try {
+    // Find comment id if exist
+    const { data: existingComments } = await github.issues.listComments({
+      issue_number: context.issue.number,
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+    });
+
+    let commentId;
+    for (let i = existingComments.length; i--; ) {
+      const c = existingComments[i];
+      if (c.user.type === "Bot" && c.body.includes(commentTitle)) {
+        commentId = c.id;
+        break;
+      }
+    }
+
+    const timestamp = Date.now();
+    if (!commentId) {
+      console.log("Creating comment...");
+      await github.issues.createComment({
+        issue_number: context.issue.number,
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        body: timestamp,
+      });
+    } else {
+      console.log("Updating comment...", commentId);
+      await github.issues.updateComment({
+        comment_id: commentId,
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        body: timestamp,
+      });
+    }
+  } catch (error) {
+    core.setFailed(error.message);
+  }
+}

--- a/.github/workflows/writing-comments.js
+++ b/.github/workflows/writing-comments.js
@@ -3,6 +3,8 @@
 // Should be removed once the test done.
 module.exports = async (github, context, core) => {
   try {
+    console.log("context", context);
+
     // Find comment id if exist
     const { data: existingComments } = await github.issues.listComments({
       issue_number: context.issue.number,

--- a/.github/workflows/writing-comments.js
+++ b/.github/workflows/writing-comments.js
@@ -1,6 +1,9 @@
 
 // It's a testing script to test dependabot writing permission
 // Should be removed once the test done.
+
+const COMMENT_ANCHOR = "dependabot_test";
+
 module.exports = async (github, context, core) => {
   try {
     console.log("context", context);
@@ -15,21 +18,22 @@ module.exports = async (github, context, core) => {
     let commentId;
     for (let i = existingComments.length; i--; ) {
       const c = existingComments[i];
-      if (c.user.type === "Bot" && c.body.includes(commentTitle)) {
+      if (c.user.type === "Bot" && c.body.includes(COMMENT_ANCHOR)) {
         commentId = c.id;
         break;
       }
     }
 
     const date = new Date();
-    const utcString = date.toUTCString();
+    const localTimeString = date.toLocaleString();
+    const commentBody = `${COMMENT_ANCHOR}: ${localTimeString}`;
     if (!commentId) {
       console.log("Creating comment...");
       await github.issues.createComment({
         issue_number: context.issue.number,
         owner: context.repo.owner,
         repo: context.repo.repo,
-        body: utcString,
+        body: commentBody,
       });
     } else {
       console.log("Updating comment...", commentId);
@@ -37,7 +41,7 @@ module.exports = async (github, context, core) => {
         comment_id: commentId,
         owner: context.repo.owner,
         repo: context.repo.repo,
-        body: utcString,
+        body: commentBody,
       });
     }
   } catch (error) {


### PR DESCRIPTION
It's an experimental action that testing whether dependabot can write commetns if the `github-token` is passed to `github-script` at [this line](https://github.com/marilyn79218/react-lazy-show/pull/41/files#diff-15c806aa509538190832852f439e9921a23bec2da81f95ed0e4bf13c14e5b160R19).

Note: this action can be removed once the test done.