### PR TITLE
fix: [dependabot write permission] Update dependent workflow name

### DIFF
--- a/.github/workflows/pr-dependabot.yml
+++ b/.github/workflows/pr-dependabot.yml
@@ -2,7 +2,7 @@ name: dependabot PR CI
 
 on:
   workflow_run:
-    workflows: ["pr-upload-data"]
+    workflows: ["Upload data at PR CI phase"]
     types:
       - completed
 


### PR DESCRIPTION
Fix a mistake in previous #45 that I didn't update the dependent workflow name in `pr-dependabot.yml` accordingly when I rename it [here](https://github.com/marilyn79218/react-lazy-show/pull/45/files#diff-e34e5951ced076a9ccec2b52a41b5cd11ee2b418d3be5c375a3f2336b5e855e7R1).