### PR TITLE
fix: [dependabot write permission] Use hash id in inline script directly

### DIFF
--- a/.github/workflows/download-cross-workflow-artifact.js
+++ b/.github/workflows/download-cross-workflow-artifact.js
@@ -8,8 +8,8 @@ fs.readdirSync(actifactFolderPath, "utf-8").forEach(file => {
     const rawFileData = fs.readFileSync(path.join(actifactFolderPath, file), "utf-8");
     const fileData = JSON.parse(rawFileData);
 
-    console.log(fileData);
     console.log(Array.isArray(fileData), fileData[0], fileData[1], fileData[2]);
+    console.log(fileData);
   }
 });
 

--- a/.github/workflows/pr-dependabot.yml
+++ b/.github/workflows/pr-dependabot.yml
@@ -19,7 +19,7 @@ jobs:
             const listPrResponse = await github.repos.listPullRequestsAssociatedWithCommit({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              commit_sha: ${{ github.event.workflow_run.head_sha }}
+              commit_sha: "${{ github.event.workflow_run.head_sha }}"
             });
             const prInfo = listPrResponse.data[0];
             console.log("get-pr-info", prInfo);

--- a/.github/workflows/pr-dependabot.yml
+++ b/.github/workflows/pr-dependabot.yml
@@ -11,27 +11,21 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - name: Get PR info
-        id: get_pr_info
-        uses: actions/github-script@v4
-        env:
-          hashId: ${{ github.event.workflow_run.head_sha }}
-        with:
-          script: |
-            const listPrResponse = await github.repos.listPullRequestsAssociatedWithCommit({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              commit_sha: process.env.hashId,
-            });            
-            const prInfo = listPrResponse.data[0];
-            console.log("get-pr-info", prInfo);
-            core.setOutput("prNumber", prInfo.number);
       - name: Display PR info
         run: |
           echo "PR outputs - ${{ steps.get_pr_info.outputs }}"
           echo "PR number - ${{ steps.get_pr_info.outputs.prNumber }}"
           echo "PR list (new) - ${{ github.event.workflow_run.pull_requests }}"
           echo "PR branch (new) - ${{ github.event.workflow_run.head_branch }}"
+      - name: List PR list
+        id: list_pr_info
+        uses: actions/github-script@v4
+        with:
+          script: |
+            const path = require('path');
+            const scriptPath = path.resolve('./.github/workflows/list-pr-info.js');
+            const prList = ${{ github.event.workflow_run.pull_requests }};
+            await require(scriptPath)(github, context, core, prList);
       - name: Download artifact once bundlesize done
         uses: dawidd6/action-download-artifact@v2
         with:

--- a/.github/workflows/pr-dependabot.yml
+++ b/.github/workflows/pr-dependabot.yml
@@ -15,12 +15,11 @@ jobs:
         id: get_pr_info
         uses: actions/github-script@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const listPrResponse = await github.repos.listPullRequestsAssociatedWithCommit({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              commit_sha: ${{ github.event.workflow_run.head_sha }},
+              commit_sha: '${{ github.event.workflow_run.head_sha }}',
             });            
             const prInfo = listPrResponse.data[0];
             console.log("get-pr-info", prInfo);

--- a/.github/workflows/pr-dependabot.yml
+++ b/.github/workflows/pr-dependabot.yml
@@ -11,6 +11,19 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
+      - name: Get PR info
+        id: get_pr_info
+        uses: actions/github-script@v4
+        with:
+          script: |
+            const listPrResponse = await github.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: ${{ github.event.workflow_run.head_sha }}
+            });
+            const prInfo = listPrResponse.data[0];
+            console.log("get-pr-info", prInfo);
+            core.setOutput("prNumber", prInfo.number);
       - name: Display PR info
         run: |
           echo "PR outputs - ${{ steps.get_pr_info.outputs }}"

--- a/.github/workflows/pr-dependabot.yml
+++ b/.github/workflows/pr-dependabot.yml
@@ -16,25 +16,20 @@ jobs:
         uses: actions/github-script@v4
         with:
           script: |
-            const path = require('path');
-            const scriptPath = path.resolve('./.github/workflows/get-pr-info.js');
-            const commitHash = ${{ github.event.workflow_run.head_sha }};
-            await require(scriptPath)(github, context, core, commitHash);
+            const listPrResponse = await github.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: ${{ github.event.workflow_run.head_sha }},
+            });            
+            const prInfo = listPrResponse.data[0];
+            console.log("get-pr-info", prInfo);
+            core.setOutput("prNumber", prInfo.number);
       - name: Display PR info
         run: |
           echo "PR outputs - ${{ steps.get_pr_info.outputs }}"
           echo "PR number - ${{ steps.get_pr_info.outputs.prNumber }}"
           echo "PR list (new) - ${{ github.event.workflow_run.pull_requests }}"
           echo "PR branch (new) - ${{ github.event.workflow_run.head_branch }}"
-      - name: List PR list
-        id: list_pr_info
-        uses: actions/github-script@v4
-        with:
-          script: |
-            const path = require('path');
-            const scriptPath = path.resolve('./.github/workflows/list-pr-info.js');
-            const prList = ${{ github.event.workflow_run.pull_requests }};
-            await require(scriptPath)(github, context, core, prList);
       - name: Download artifact once bundlesize done
         uses: dawidd6/action-download-artifact@v2
         with:
@@ -56,5 +51,6 @@ jobs:
           script: |
             const path = require('path');
             const scriptPath = path.resolve('./.github/workflows/writing-comments.js');
+            const prNumber = ${{ steps.get_pr_info.outputs.prNumber }};
             const writingData = ${{ steps.collect_data.outputs.downloadedData }};
-            await require(scriptPath)(github, context, core, writingData);
+            await require(scriptPath)(github, context, core, prNumber, writingData);

--- a/.github/workflows/pr-dependabot.yml
+++ b/.github/workflows/pr-dependabot.yml
@@ -14,12 +14,14 @@ jobs:
       - name: Get PR info
         id: get_pr_info
         uses: actions/github-script@v4
+        env:
+          hashId: ${{ github.event.workflow_run.head_sha }}
         with:
           script: |
             const listPrResponse = await github.repos.listPullRequestsAssociatedWithCommit({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              commit_sha: '${{ github.event.workflow_run.head_sha }}',
+              commit_sha: process.env.hashId,
             });            
             const prInfo = listPrResponse.data[0];
             console.log("get-pr-info", prInfo);

--- a/.github/workflows/pr-dependabot.yml
+++ b/.github/workflows/pr-dependabot.yml
@@ -15,6 +15,7 @@ jobs:
         id: get_pr_info
         uses: actions/github-script@v4
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const listPrResponse = await github.repos.listPullRequestsAssociatedWithCommit({
               owner: context.repo.owner,

--- a/.github/workflows/pr-dependabot.yml
+++ b/.github/workflows/pr-dependabot.yml
@@ -19,7 +19,7 @@ jobs:
             const listPrResponse = await github.repos.listPullRequestsAssociatedWithCommit({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              commit_sha: "${{ github.event.workflow_run.head_sha }}"
+              commit_sha: ${{ github.event.workflow_run.head_sha }}
             });
             const prInfo = listPrResponse.data[0];
             console.log("get-pr-info", prInfo);

--- a/.github/workflows/writing-comments.js
+++ b/.github/workflows/writing-comments.js
@@ -4,14 +4,15 @@
 
 const COMMENT_ANCHOR = "dependabot_test";
 
-module.exports = async (github, context, core, data) => {
+module.exports = async (github, context, core, prNumber, data) => {
   try {
+    console.log("prNumber", prNumber);
     console.log("data", data);
     console.log("context", context);
 
     // Find comment id if exist
     const { data: existingComments } = await github.issues.listComments({
-      issue_number: context.issue.number,
+      issue_number: prNumber,
       owner: context.repo.owner,
       repo: context.repo.repo,
     });
@@ -29,7 +30,7 @@ module.exports = async (github, context, core, data) => {
     if (!commentId) {
       console.log("Creating comment...");
       await github.issues.createComment({
-        issue_number: context.issue.number,
+        issue_number: prNumber,
         owner: context.repo.owner,
         repo: context.repo.repo,
         body: commentBody,


### PR DESCRIPTION
Use hash id from workflow in inline script to retrieve corresponding pr number directly.

Because the previous error was
```jsx
const scriptPath = path.resolve('./.github/workflows/get-pr-info.js');
const commitHash = cfff14901fe5fcea05ee412f9c9b1b58f3998af9;
await require(scriptPath)(github, context, core, commitHash);

Unhandled error: ReferenceError: cfff14901fe5fcea05ee412f9c9b1b58f3998af9 is not defined
```