### PR TITLE
refactor: [dependabot write permission] Export utils

### DIFF
--- a/.github/workflows/pr-dependabot/utils.js
+++ b/.github/workflows/pr-dependabot/utils.js
@@ -45,3 +45,7 @@ const readFileFromArtifact = () => {
   }
 };
 
+module.exports = {
+  getPrInfo,
+  readFileFromArtifact,
+};


### PR DESCRIPTION
Another mistake in #61 where I forgot to export util functions.