### PR TITLE
feat: [dependabot write permission] Set up permission key for dependabot

### DIFF
--- a/.github/workflows/dependabot-comments/permission-key.js
+++ b/.github/workflows/dependabot-comments/permission-key.js
@@ -1,0 +1,44 @@
+const COMMENT_ANCHOR = "dependabot_permission_key";
+
+module.exports = async (github, context, core) => {
+  try {
+    // Find comment id if exist
+    const { data: existingComments } = await github.issues.listComments({
+      issue_number: context.issue.number,
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+    });
+
+    let commentId;
+    for (let i = existingComments.length; i--; ) {
+      const c = existingComments[i];
+      if (c.user.type === "Bot" && c.body.includes(COMMENT_ANCHOR)) {
+        commentId = c.id;
+        break;
+      }
+    }
+
+    const date = new Date();
+    const localTimeString = date.toLocaleString();
+    const commentBody = `${COMMENT_ANCHOR}: ${localTimeString}`;
+    if (!commentId) {
+      console.log("Creating comment...");
+      await github.issues.createComment({
+        issue_number: context.issue.number,
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        body: commentBody,
+      });
+    } else {
+      console.log("Updating comment...", commentId);
+      await github.issues.updateComment({
+        comment_id: commentId,
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        body: commentBody,
+      });
+    }
+  } catch (error) {
+    core.setFailed(error.message);
+  }
+}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,3 +24,21 @@ jobs:
       - name: Display structure of downloaded files
         run: ls -R
         working-directory: .
+  dependabot-comments:
+    runs-on: ubuntu-18.04
+    # Key change: modify the permission for this job taht ran by dependabot
+    # Doc: https://docs.github.com/en/actions/reference/authentication-in-a-workflow#modifying-the-permissions-for-the-github_token
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14.15.4"
+      - name: "Writing comments"
+        uses: actions/github-script@v4
+        with:
+          script: |
+            const path = require('path');
+            const scriptPath = path.resolve('./.github/workflows/dependabot-comments/permission-key.js');
+            await require(scriptPath)(github, context, core);

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,7 +29,18 @@ jobs:
     # Key change: modify the permission for this job taht ran by dependabot
     # Doc: https://docs.github.com/en/actions/reference/authentication-in-a-workflow#modifying-the-permissions-for-the-github_token
     permissions:
+      actions: read
+      checks: read
+      contents: read
+      deployments: read
+      discussions: read
       issues: write
+      metadata: read
+      packages: read
+      pullRequests: read
+      repositoryProjects: read
+      securityEvents: read
+      statuses: read
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,13 +33,8 @@ jobs:
       checks: read
       contents: read
       deployments: read
-      discussions: read
       issues: write
-      metadata: read
       packages: read
-      pullRequests: read
-      repositoryProjects: read
-      securityEvents: read
       statuses: read
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,13 +29,13 @@ jobs:
     # Key change: modify the permission for this job taht ran by dependabot
     # Doc: https://docs.github.com/en/actions/reference/authentication-in-a-workflow#modifying-the-permissions-for-the-github_token
     permissions:
-      actions: read
-      checks: read
-      contents: read
-      deployments: read
+      actions: write
+      checks: write
+      contents: write
+      deployments: write
       issues: write
-      packages: read
-      statuses: read
+      packages: write
+      statuses: write
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2


### PR DESCRIPTION
According to the [doc](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#modifying-the-permissions-for-the-github_token), we can modify the permission on a specific service ([list](https://docs.github.com/en/rest/reference/permissions-required-for-github-apps)) in a workflow or in a job. 
Hence this PR is to see whether it also works for dependabot. 

Note: have to re-open the dependabot PR after this one get merged to see the effect.

That said in [this thread](https://github.com/marilyn79218/react-lazy-show/pull/70#issuecomment-875709569), have no idea this PR doesn't work yet, but we still learned sth in these doc:
- [Modifying the permissions for the GITHUB_TOKEN](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#modifying-the-permissions-for-the-github_token)
- [[Example] passing the GITHUB_TOKEN as an input](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#example-1-passing-the-github_token-as-an-input)
- [Permission on "issues"](https://docs.github.com/en/rest/reference/permissions-required-for-github-apps#permission-on-issues)
- [Create an issue comment](https://docs.github.com/en/rest/reference/issues#create-an-issue-comment)
- [Disabling or limiting GitHub Actions](https://docs.github.com/en/github/administering-a-repository/managing-repository-settings/disabling-or-limiting-github-actions-for-a-repository#setting-the-permissions-of-the-github_token-for-a-repository)