### PR TITLE
fix: [dependabot write permission] Fix workflow name

### DIFF
--- a/.github/workflows/master-download-cross-workflow-artifact.yml
+++ b/.github/workflows/master-download-cross-workflow-artifact.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Download artifact once PR merged
         uses: dawidd6/action-download-artifact@v2
         with:
-          workflow: pr-upload-data.yml
+          workflow: pr.yml
           name: data-arctifact
           pr: ${{ steps.get_pr_info.outputs.prNumber }}
       - name: Display structure of downloaded files

--- a/.github/workflows/workflow-run.yml
+++ b/.github/workflows/workflow-run.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Download artifact from other workflow
         uses: dawidd6/action-download-artifact@v2
         with:
-          workflow: pr-upload-data.yml
+          workflow: pr.yml
           # The artifact name comes from previous workflow "pr"
           name: data-arctifact
           branch: ${{ github.event.workflow_run.head_branch }}


### PR DESCRIPTION
In previous pr #69, we renamed workflow file name `.github/workflows/pr-upload-data.yml` to `.github/workflows/pr.yml` but we didn't update its name in the dependent workflow accordingly, this PR fixes it.