### PR TITLE
experiment: [dependabot write permission] Download artifact for failure workflow

### DIFF
--- a/.github/workflows/workflow-run.yml
+++ b/.github/workflows/workflow-run.yml
@@ -59,6 +59,8 @@ jobs:
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: pr.yml
+          # Search artifact from these workflow conclusion/ status, even it's a failure
+          workflow_conclusion: "completed,success,failure"
           # The artifact name comes from previous workflow "pr"
           name: data-arctifact
           branch: ${{ github.event.workflow_run.head_branch }}


### PR DESCRIPTION
In testing pr #71 where I added one failed job in `pr.yml` on purpose (and the existing job `upload-data` doesn't get changed so it still remains successful), but this one new added failure job will cause the `workflow_run` failed at downloading artifact step because this downloading step in `workflow_run` is configured as only searching `completed,success` workflows [by default](https://github.com/dawidd6/action-download-artifact#usage), which results in [`RunID Not Found`](https://github.com/dawidd6/action-download-artifact/blob/master/main.js#L60) error.

![Screen Shot 2021-07-08 at 3 53 27 PM](https://user-images.githubusercontent.com/22482071/124884220-a8b72d00-e004-11eb-975f-57f9c6329b45.png)