### PR TITLE
experiment: [dependabot write permission] Download artifact for all the workflow conclusions

### DIFF
--- a/.github/workflows/workflow-run.yml
+++ b/.github/workflows/workflow-run.yml
@@ -59,8 +59,8 @@ jobs:
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: pr.yml
-          # Search artifact from these workflow conclusion/ status, even it's a failure
-          workflow_conclusion: "completed,success,failure"
+          # Search artifact from these workflow conclusions, even it's a failure
+          workflow_conclusion: "success,failure"
           # The artifact name comes from previous workflow "pr"
           name: data-arctifact
           branch: ${{ github.event.workflow_run.head_branch }}


### PR DESCRIPTION
As title, since #73 seems still doesn't work, after checking [the doc](https://docs.github.com/en/rest/reference/checks#create-a-check-run) about workflow status, this time we try with `success,failure` conclusion only.