### PR TITLE
experiment: [dependabot write permission] List workflow runs & artifacts.

### DIFF
--- a/.github/workflows/workflow-run.yml
+++ b/.github/workflows/workflow-run.yml
@@ -85,8 +85,6 @@ jobs:
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: pr.yml
-          # Search artifact from these workflow conclusions, even it's a failure
-          workflow_conclusion: "success,failure"
           # The artifact name comes from previous workflow "pr"
           name: data-arctifact
           branch: ${{ github.event.workflow_run.head_branch }}

--- a/.github/workflows/workflow-run.yml
+++ b/.github/workflows/workflow-run.yml
@@ -55,6 +55,32 @@ jobs:
         run: |
           echo "PR branch  - ${{ github.event.workflow_run.head_branch }}"
           echo "PR commit - ${{ github.event.workflow_run.head_sha }}"
+      - name: "List artifacts"
+        uses: actions/github-script@v4
+        with:
+          script: |
+            const artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: '${{github.event.workflow_run.id }}'
+            });
+            console.log("artifacts", artifacts);
+            const matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "data-arctifact"
+            })[0];
+            console.log("matchArtifact", matchArtifact);
+      - name: "List workflow runs"
+        uses: actions/github-script@v4
+        with:
+          script: |
+            const runs = await github.actions.listWorkflowRuns({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               workflow_id: '${{github.event.workflow.id }}'
+            });
+            for (const run of runs) {
+              console.log("run", run);
+            }
       - name: Download artifact from other workflow
         uses: dawidd6/action-download-artifact@v2
         with:


### PR DESCRIPTION
Since both the conclusions of `dawidd6/action-download-artifact@v2` specified in #73 and #74 still fails at downloading an artifact if a [previous pr job](https://github.com/marilyn79218/react-lazy-show/pull/71/files#diff-15c806aa509538190832852f439e9921a23bec2da81f95ed0e4bf13c14e5b160R27) failed.

Instead of blindly guessing what conclusion I should specify for this case, let's log it first and see what are workflow run conclusions we want.

Also, let's remove the `workflow_conclusion` param first (i.e., revert #73 #74) because it's making all the workflow run failed even it's a success pr.