### PR TITLE
experiment: [dependabot write permission] Add explanation for `listWorkflowRuns` API

### DIFF
--- a/.github/workflows/list-workflow-runs/index.js
+++ b/.github/workflows/list-workflow-runs/index.js
@@ -2,6 +2,11 @@ module.exports = async (github, context, core, workflowId) => {
   try {
     console.log("workflowId", workflowId);
 
+    // API doc: https://octokit.github.io/rest.js/v18#actions-list-workflow-runs
+    // List of status & conclusion values
+    //    Ref 1: https://docs.github.com/en/rest/reference/checks#check-runs
+    //    Ref 2: https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#webhook-payload-object
+    // Code example: https://github.com/dawidd6/action-download-artifact/blob/master/main.js#L60
     console.log("No status ---------------------------------------");
     let runs = await github.actions.listWorkflowRuns({
       owner: context.repo.owner,
@@ -13,77 +18,119 @@ module.exports = async (github, context, core, workflowId) => {
       console.log("run", run);
     }
 
-    console.log("Failure status ---------------------------------------");
-    runs = await github.actions.listWorkflowRuns({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      workflow_id: workflowId,
-      status: "failure",
-    });
-    console.log("Failure runs", runs)
-    for (const run of runs.data.workflow_runs) {
-      console.log("run", run);
-    }
+    // [Things learned]
+    // listWorkflowRuns() API returns all the workflows that matches ALL the status & conclusions you specify.
 
-    console.log("Success status ---------------------------------------");
-    runs = await github.actions.listWorkflowRuns({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      workflow_id: workflowId,
-      status: "success",
-    });
-    console.log("Success runs", runs)
-    for (const run of runs.data.workflow_runs) {
-      console.log("run", run);
-    }
+    // The conclusion of a workflow is "the highest priority check run conclusion in the check suite's conclusion".
+    // Or you can say it is "The summary conclusion for all check runs that are part of the check suite"
+    // For example, if three check runs have conclusions of "timed_out", "success", and "neutral",
+    // then the check suite conclusion will be timed_out.
 
-    console.log("Completed status ---------------------------------------");
-    runs = await github.actions.listWorkflowRuns({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      workflow_id: workflowId,
-      status: "completed",
-    });
-    console.log("Completed runs", runs)
-    for (const run of runs.data.workflow_runs) {
-      console.log("run", run);
-    }
+    // Note: the priority of check run conclusion is
+    // "action_required", "cancelled", "timed_out", "failure", "neutral", and "success"
+    // Ref: https://docs.github.com/en/rest/guides/getting-started-with-the-checks-api#about-check-suites
+    // Ref: https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#check_suite
 
-    console.log("Complete & failure status ---------------------------------------");
-    runs = await github.actions.listWorkflowRuns({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      workflow_id: workflowId,
-      status: "completed,failure",
-    });
-    console.log("Completed & failure runs", runs);
-    for (const run of runs.data.workflow_runs) {
-      console.log("run", run);
-    }
+    // For example, from my observation,
+    // if you specify status "completed,failure" in this API,
+    // it returns all the workflows that are in "completed" status and "failure" conclusion,
+    // which means the workflow is "completed" but one of its job has "failure" conclusion.
 
-    console.log("Complete & success status ---------------------------------------");
-    runs = await github.actions.listWorkflowRuns({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      workflow_id: workflowId,
-      status: "completed,success",
-    });
-    console.log("Completed & success runs", runs);
-    for (const run of runs.data.workflow_runs) {
-      console.log("run", run);
-    }
+    // In another point of view, if a run has "completed" status and "failure" conclusion,
+    // then it will only be returned if you specify below status combinations in listWorkflowRuns() API:
+    // 1. Query without status param
+    // 2. Query with status value "failure"
+    // 3. Query with status value "completed"
+    // 4. Query with status value "completed,failure"
 
-    console.log("Success & failure status ---------------------------------------");
-    runs = await github.actions.listWorkflowRuns({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      workflow_id: workflowId,
-      status: "success,failure",
-    });
-    console.log("Success & failure runs", runs);
-    for (const run of runs.data.workflow_runs) {
-      console.log("run", run);
-    }
+
+
+
+
+    // ------------- Log for testing this listWorkflowRuns API behaviors -------------
+
+    // How to run them? Uncomment and execute them in workflow-run.yml
+    // Or you can simply see the logs in the "Display workflow info" section of the CI hashboard
+    // It shows you the status and conclusion when the "workflow_run" event is triggered
+    // Ref: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_run
+
+    // The number of returned workflow runs in this case is > 0
+    // console.log("Failure status ---------------------------------------");
+    // runs = await github.actions.listWorkflowRuns({
+    //   owner: context.repo.owner,
+    //   repo: context.repo.repo,
+    //   workflow_id: workflowId,
+    //   status: "failure",
+    // });
+    // console.log("Failure runs", runs)
+    // for (const run of runs.data.workflow_runs) {
+    //   console.log("run", run);
+    // }
+
+    // The number of returned workflow runs in this case is > 0
+    // console.log("Success status ---------------------------------------");
+    // runs = await github.actions.listWorkflowRuns({
+    //   owner: context.repo.owner,
+    //   repo: context.repo.repo,
+    //   workflow_id: workflowId,
+    //   status: "success",
+    // });
+    // console.log("Success runs", runs)
+    // for (const run of runs.data.workflow_runs) {
+    //   console.log("run", run);
+    // }
+
+    // The number of returned workflow runs in this case is > 0
+    // console.log("Completed status ---------------------------------------");
+    // runs = await github.actions.listWorkflowRuns({
+    //   owner: context.repo.owner,
+    //   repo: context.repo.repo,
+    //   workflow_id: workflowId,
+    //   status: "completed",
+    // });
+    // console.log("Completed runs", runs)
+    // for (const run of runs.data.workflow_runs) {
+    //   console.log("run", run);
+    // }
+
+    // The number of returned workflow runs in this case is > 0
+    // console.log("Complete & failure status ---------------------------------------");
+    // runs = await github.actions.listWorkflowRuns({
+    //   owner: context.repo.owner,
+    //   repo: context.repo.repo,
+    //   workflow_id: workflowId,
+    //   status: "completed,failure",
+    // });
+    // console.log("Completed & failure runs", runs);
+    // for (const run of runs.data.workflow_runs) {
+    //   console.log("run", run);
+    // }
+
+    // The number of returned workflow runs in this case is > 0
+    // console.log("Complete & success status ---------------------------------------");
+    // runs = await github.actions.listWorkflowRuns({
+    //   owner: context.repo.owner,
+    //   repo: context.repo.repo,
+    //   workflow_id: workflowId,
+    //   status: "completed,success",
+    // });
+    // console.log("Completed & success runs", runs);
+    // for (const run of runs.data.workflow_runs) {
+    //   console.log("run", run);
+    // }
+
+    // The number of returned workflow runs in this case is === 0
+    // console.log("Success & failure status ---------------------------------------");
+    // runs = await github.actions.listWorkflowRuns({
+    //   owner: context.repo.owner,
+    //   repo: context.repo.repo,
+    //   workflow_id: workflowId,
+    //   status: "success,failure",
+    // });
+    // console.log("Success & failure runs", runs);
+    // for (const run of runs.data.workflow_runs) {
+    //   console.log("run", run);
+    // }
   } catch (error) {
     core.setFailed(error.message);
   }

--- a/.github/workflows/workflow-run.yml
+++ b/.github/workflows/workflow-run.yml
@@ -84,6 +84,7 @@ jobs:
         with:
           workflow: pr.yml
           # Download artifact from success workflow only
+          # See why we only specify "completed" workflow in "/list-workflow-runs/index.js"
           workflow_conclusion: "completed"
           # The artifact name comes from previous workflow "pr"
           name: data-arctifact

--- a/.github/workflows/workflow-run.yml
+++ b/.github/workflows/workflow-run.yml
@@ -57,28 +57,21 @@ jobs:
           echo "PR commit - ${{ github.event.workflow_run.head_sha }}"
           echo "Workflow status - ${{ github.event.workflow_run.status }}"
           echo "Workflow conclusion - ${{ github.event.workflow_run.conclusion }}"
-      - name: "List artifacts"
-        uses: actions/github-script@v4
-        with:
-          script: |
-            const artifacts = await github.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: '${{github.event.workflow_run.id }}'
-            });
-            console.log("artifacts", artifacts);
-            const matchArtifact = artifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "data-arctifact"
-            })[0];
-            console.log("matchArtifact", matchArtifact);
-      - name: "List workflow runs"
-        uses: actions/github-script@v4
-        with:
-          script: |
-            const path = require('path');
-            const scriptPath = path.resolve('./.github/workflows/list-workflow-runs/index.js');
-            const workflowId = `${{ github.event.workflow.id }}`;
-            await require(scriptPath)(github, context, core, workflowId);
+      # TODO: remove `dawidd6/action-download-artifact@v2` and download artifact by ourself
+      # - name: "List artifacts"
+      #   uses: actions/github-script@v4
+      #   with:
+      #     script: |
+      #       const artifacts = await github.actions.listWorkflowRunArtifacts({
+      #          owner: context.repo.owner,
+      #          repo: context.repo.repo,
+      #          run_id: '${{github.event.workflow_run.id }}'
+      #       });
+      #       console.log("artifacts", artifacts);
+      #       const matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+      #         return artifact.name == "data-arctifact"
+      #       })[0];
+      #       console.log("matchArtifact", matchArtifact);
       - name: Download artifact from other workflow
         uses: dawidd6/action-download-artifact@v2
         with:


### PR DESCRIPTION
Starting from #73 - #81 PR series, all we wanted to do is to test whether the `workflow run` workflow can still successfully execute even when there's a failed job that happened in the previous dependent workflow `pr` (see #71).

But I stuck at the error raised by external GH action `dawidd6/action-download-artifact` as described in #73 which indicate it cannot find the artifact from the workflow run list with its [default configuration](https://github.com/dawidd6/action-download-artifact#usage), so I started these PR series and tried to understand how to actually leverage the `listWorkflowRuns` API that is used [dawidd6/action-download-artifact](https://github.com/dawidd6/action-download-artifact/blob/master/main.js#L60).

Hence writing comments in this PR as a note for future.

Back to the topic, it was actually successful in [#78](https://github.com/marilyn79218/react-lazy-show/pull/78/files#diff-791e06a00e373dcb530ab45bfc3ed3f9a576b7e4b6edf75e9aef08fe1251d2faR86) when we set the `workflow_conclusion` param as `completed`.
Can see the workflow triggered by #71 has a failed `pr` workflow but still has a successful `workflow run` workflow 🎉 

| Workflow name | `pr` (failure) | `workflow run` (success) |
| --------------- | ----- | --------------- | 
| | ![image (35)](https://user-images.githubusercontent.com/22482071/125071480-e642b580-e0eb-11eb-86d0-451a4413e3ce.jpg) | ![image (36)](https://user-images.githubusercontent.com/22482071/125071493-ea6ed300-e0eb-11eb-8af6-34fd5a902369.jpg) |