### PR TITLE
feat: [dependabot write permission] Log workflow actor

### DIFF
--- a/.github/workflows/workflow-run.yml
+++ b/.github/workflows/workflow-run.yml
@@ -55,6 +55,7 @@ jobs:
         run: |
           echo "PR branch  - ${{ github.event.workflow_run.head_branch }}"
           echo "PR commit - ${{ github.event.workflow_run.head_sha }}"
+          echo "Workflow actor - ${{ github.actor }}"
           echo "Workflow status - ${{ github.event.workflow_run.status }}"
           echo "Workflow conclusion - ${{ github.event.workflow_run.conclusion }}"
       # TODO: remove `dawidd6/action-download-artifact@v2` and download artifact by ourself


### PR DESCRIPTION
As title, log the actor to only allows dependabot running `workflow run` workflow in future (Update: which is #84).

Ref: https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context