### PR TITLE
feat: [dependabot write permission] Fix artifact downloading path

### DIFF
--- a/.github/workflows/dependabot-comments/index.js
+++ b/.github/workflows/dependabot-comments/index.js
@@ -8,7 +8,8 @@ const COMMENT_ANCHOR = "dependabot_comments";
 // Allowing contributor AND dependabot to write comments to a pull request
 module.exports = async (github, context, core, commitHash) => {
   try {
-    const fileData = readFileFromArtifact();
+    const firstFileData = readFileFromArtifact("first-data-arctifact");
+    const secondFileData = readFileFromArtifact("second-data-arctifact");
 
     const prInfo = await getPrInfo(github, context, core, commitHash);
     const prNumber = prInfo.number;
@@ -32,7 +33,7 @@ module.exports = async (github, context, core, commitHash) => {
       }
     }
 
-    const commentBody = `${fileData} (${commitHash}) <sub>${COMMENT_ANCHOR}</sub>`;
+    const commentBody = `${firstFileData} (${commitHash}) <sub>${COMMENT_ANCHOR}</sub>`;
     if (!commentId) {
       console.log("Creating comment...");
       await github.issues.createComment({

--- a/.github/workflows/dependabot-comments/utils.js
+++ b/.github/workflows/dependabot-comments/utils.js
@@ -25,10 +25,10 @@ const getPrInfo = async (github, context, core, commitHash) => {
 };
 
 // Read artifact content that was uploaded in previous action
-const readFileFromArtifact = () => {
+const readFileFromArtifact = artifactName => {
   try {
     let fileData;
-    const actifactFolderPath = path.join(process.cwd());
+    const actifactFolderPath = path.join(process.cwd(), artifactName);
     fs.readdirSync(actifactFolderPath, "utf-8").forEach(file => {
       if (file.endsWith(".txt")) {
         const rawFileData = fs.readFileSync(

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,14 +13,14 @@ jobs:
       - name: Generate data
         id: generate_data
         run: |
-          mkdir downloads
-          cd downloads
+          # mkdir downloads
+          # cd downloads
           echo "$(node ../.github/workflows/generate-data.js)" > generated-first-data.txt
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
           name: first-data-arctifact
-          path: downloads
+          # path: downloads
       - name: Display structure of downloaded files
         run: ls -R
         working-directory: .
@@ -31,14 +31,14 @@ jobs:
       - name: Generate data
         id: generate_data
         run: |
-          mkdir downloads
-          cd downloads
+          # mkdir downloads
+          # cd downloads
           echo "$(node ../.github/workflows/generate-data.js)" > generated-second-data.txt
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
           name: second-data-arctifact
-          path: downloads
+          # path: downloads
       - name: Display structure of downloaded files
         run: ls -R
         working-directory: .

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: first-data-arctifact
-          # path: downloads
+          path: generated-first-data.txt
       - name: Display structure of downloaded files
         run: ls -R
         working-directory: .
@@ -38,7 +38,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: second-data-arctifact
-          # path: downloads
+          path: generated-second-data.txt
       - name: Display structure of downloaded files
         run: ls -R
         working-directory: .


### PR DESCRIPTION
In previous #85, we uploaded 2 artifacts and trying to download them at once. But turns out the data file itself is placed under the `${process.env.GITHUB_WORKSPACE}/${artifact_name}/xxx.txt`, see screenshot.

Secondly, this PR also removes the additional `downaload` folder when uploading.

![Screen Shot 2021-07-13 at 12 44 08 PM](https://user-images.githubusercontent.com/22482071/125392173-40879300-e3d8-11eb-843f-69b2315125ac.png)