### PR TITLE
feat: [dependabot write permission] Add logs

### DIFF
--- a/.github/workflows/dependabot-comments/utils.js
+++ b/.github/workflows/dependabot-comments/utils.js
@@ -26,19 +26,27 @@ const getPrInfo = async (github, context, core, commitHash) => {
 
 // Read artifact content that was uploaded in previous action
 const readFileFromArtifact = artifactName => {
+  console.log("actifact name", artifactName);
   try {
     let fileData;
     const actifactFolderPath = path.join(process.cwd(), artifactName);
+    console.log("actifact path", actifactFolderPath);
     fs.readdirSync(actifactFolderPath, "utf-8").forEach(file => {
+      console.log("file", file);
+
       if (file.endsWith(".txt")) {
+        console.log("txt file");
         const rawFileData = fs.readFileSync(
           path.join(actifactFolderPath, file),
           "utf-8",
         );
+        console.log("txt file - raw file data", rawFileData);
         fileData = JSON.parse(rawFileData);
+        console.log("txt file - file data", fileData);
       }
     });
 
+    console.log("file data", fileData);
     return fileData;
   } catch (err) {
     console.error(err.message);


### PR DESCRIPTION
In previous #86, we have used the artifact name as folder in the path to read the `.txt` file, but somehow it still doesn't work (see screenshot). Hence this PR simply adds logs to see what's going wrong.

![Screen Shot 2021-07-13 at 1 04 52 PM](https://user-images.githubusercontent.com/22482071/125393692-feac1c00-e3da-11eb-879c-1b3e8d39f3a6.png)
