### PR TITLE
feat: [dependabot write permission] Download artifacts in different jobs

### DIFF
--- a/.github/workflows/dependabot-comments/index.js
+++ b/.github/workflows/dependabot-comments/index.js
@@ -8,8 +8,8 @@ const COMMENT_ANCHOR = "dependabot_comments";
 // Allowing contributor AND dependabot to write comments to a pull request
 module.exports = async (github, context, core, commitHash) => {
   try {
-    const firstFileData = readFileFromArtifact("first-data-arctifact");
-    const secondFileData = readFileFromArtifact("second-data-arctifact");
+    const firstFileData = readFileFromArtifact("generated-first-data.txt");
+    const secondFileData = readFileFromArtifact("generated-second-data.txt");
 
     const prInfo = await getPrInfo(github, context, core, commitHash);
     const prNumber = prInfo.number;

--- a/.github/workflows/dependabot-comments/utils.js
+++ b/.github/workflows/dependabot-comments/utils.js
@@ -25,17 +25,17 @@ const getPrInfo = async (github, context, core, commitHash) => {
 };
 
 // Read artifact content that was uploaded in previous action
-const readFileFromArtifact = artifactName => {
-  console.log("actifact name", artifactName);
+const readFileFromArtifact = filename => {
+  console.log("filename", filename);
   try {
     let fileData;
-    const actifactFolderPath = path.join(process.cwd(), artifactName);
+    const actifactFolderPath = path.join(process.cwd());
     console.log("actifact path", actifactFolderPath);
     fs.readdirSync(actifactFolderPath, "utf-8").forEach(file => {
       console.log("file", file);
 
-      if (file.endsWith(".txt")) {
-        console.log("txt file");
+      if (file.endsWith(".txt") && file === filename) {
+        console.log("txt file", file);
         const rawFileData = fs.readFileSync(
           path.join(actifactFolderPath, file),
           "utf-8",

--- a/.github/workflows/workflow-run.yml
+++ b/.github/workflows/workflow-run.yml
@@ -76,7 +76,7 @@ jobs:
       #         return artifact.name == "first-data-arctifact"
       #       })[0];
       #       console.log("matchArtifact", matchArtifact);
-      - name: Download artifact from other workflow
+      - name: Download first artifact from other workflow
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: pr.yml
@@ -84,8 +84,17 @@ jobs:
           # See why we only specify "completed" workflow in "/list-workflow-runs/index.js"
           workflow_conclusion: "completed"
           # The artifact name comes from previous workflow "pr"
-          # Test: remove "name" attribute to download all artifacts at once
-          # name: first-data-arctifact
+          name: first-data-arctifact
+          branch: ${{ github.event.workflow_run.head_branch }}
+      - name: Download second artifact from other workflow
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: pr.yml
+          # Download artifact from success workflow only
+          # See why we only specify "completed" workflow in "/list-workflow-runs/index.js"
+          workflow_conclusion: "completed"
+          # The artifact name comes from previous workflow "pr"
+          name: second-data-arctifact
           branch: ${{ github.event.workflow_run.head_branch }}
       - name: Display structure of downloaded files
         run: ls -R


### PR DESCRIPTION
In previous #85 - #87, we downloaded all artifacts at once but failed to read the file data, have no idea the reason. 
Hence this PR tries another way which downloads artifacts in different jobs.