### PR TITLE
feat: [dependabot write permission] Download all artifacts at once

### DIFF
--- a/.github/workflows/dependabot-comments/index.js
+++ b/.github/workflows/dependabot-comments/index.js
@@ -8,8 +8,8 @@ const COMMENT_ANCHOR = "dependabot_comments";
 // Allowing contributor AND dependabot to write comments to a pull request
 module.exports = async (github, context, core, commitHash) => {
   try {
-    const firstFileData = readFileFromArtifact("generated-first-data.txt");
-    const secondFileData = readFileFromArtifact("generated-second-data.txt");
+    const firstFileData = readFileFromArtifact("first-data-arctifact");
+    const secondFileData = readFileFromArtifact("second-data-arctifact");
     const fileData = firstFileData.concat(secondFileData);
 
     const prInfo = await getPrInfo(github, context, core, commitHash);

--- a/.github/workflows/dependabot-comments/utils.js
+++ b/.github/workflows/dependabot-comments/utils.js
@@ -25,16 +25,16 @@ const getPrInfo = async (github, context, core, commitHash) => {
 };
 
 // Read artifact content that was uploaded in previous action
-const readFileFromArtifact = filename => {
-  console.log("filename", filename);
+const readFileFromArtifact = artifactName => {
+  console.log("artifact name", artifactName);
   try {
     let fileData;
-    const actifactFolderPath = path.join(process.cwd());
+    const actifactFolderPath = path.join(process.cwd(), artifactName);
     console.log("actifact path", actifactFolderPath);
     fs.readdirSync(actifactFolderPath, "utf-8").forEach(file => {
       console.log("file", file);
 
-      if (file.endsWith(".txt") && file === filename) {
+      if (file.endsWith(".txt")) {
         console.log("txt file", file);
         const rawFileData = fs.readFileSync(
           path.join(actifactFolderPath, file),

--- a/.github/workflows/workflow-run.yml
+++ b/.github/workflows/workflow-run.yml
@@ -84,17 +84,8 @@ jobs:
           # See why we only specify "completed" workflow in "/list-workflow-runs/index.js"
           workflow_conclusion: "completed"
           # The artifact name comes from previous workflow "pr"
-          name: first-data-arctifact
-          branch: ${{ github.event.workflow_run.head_branch }}
-      - name: Download second artifact from other workflow
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          workflow: pr.yml
-          # Download artifact from success workflow only
-          # See why we only specify "completed" workflow in "/list-workflow-runs/index.js"
-          workflow_conclusion: "completed"
-          # The artifact name comes from previous workflow "pr"
-          name: second-data-arctifact
+          # Remove "name" attribute to download all artifacts at once
+          # name: first-data-arctifact
           branch: ${{ github.event.workflow_run.head_branch }}
       - name: Display structure of downloaded files
         run: ls -R


### PR DESCRIPTION
Since the artifacts file data are downloaded and get read [successfully](https://github.com/marilyn79218/react-lazy-show/pull/89#issuecomment-878806818) in #88 #89, this PR reverts the downloading strategy back to `download all artifacts at once` (instead of downloading them in different jobs), also use the artifact name instead of filename when downloading.