### PR TITLE
feat: [dependabot write permission] Remove logs

### DIFF
--- a/.github/workflows/dependabot-comments/utils.js
+++ b/.github/workflows/dependabot-comments/utils.js
@@ -26,27 +26,19 @@ const getPrInfo = async (github, context, core, commitHash) => {
 
 // Read artifact content that was uploaded in previous action
 const readFileFromArtifact = artifactName => {
-  console.log("artifact name", artifactName);
   try {
     let fileData;
     const actifactFolderPath = path.join(process.cwd(), artifactName);
-    console.log("actifact path", actifactFolderPath);
     fs.readdirSync(actifactFolderPath, "utf-8").forEach(file => {
-      console.log("file", file);
-
       if (file.endsWith(".txt")) {
-        console.log("txt file", file);
         const rawFileData = fs.readFileSync(
           path.join(actifactFolderPath, file),
           "utf-8",
         );
-        console.log("txt file - raw file data", rawFileData);
         fileData = JSON.parse(rawFileData);
-        console.log("txt file - file data", fileData);
       }
     });
 
-    console.log("file data", fileData);
     return fileData;
   } catch (err) {
     console.error(err.message);

--- a/.github/workflows/workflow-run.yml
+++ b/.github/workflows/workflow-run.yml
@@ -48,8 +48,7 @@ jobs:
   dependabot-comments:
     runs-on: ubuntu-18.04
     # Operators: https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#operators
-    # Test: remove "if" condition check for temporary
-    # if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v2
       - name: Display workflow info


### PR DESCRIPTION
In previous #85 - #90, we have successfully
1. Uploaded and downloads multiple artifacts with the external `action-download-artifact` action.
2. Read the data in each of these artifacts correctly.
3. Writing comment to the pr

This pr removes some temporary codes that we made previously
(a) Remove logs
(b) Add back the `if` condition check in the `workflow_run` workflow.
