### PR TITLE
feat: [dependabot write permission] Only allows triggered by `pr` event

### DIFF
--- a/.github/workflows/workflow-run.yml
+++ b/.github/workflows/workflow-run.yml
@@ -48,8 +48,13 @@ jobs:
   # Or [PR #58](https://github.com/marilyn79218/react-lazy-show/pull/58)
   dependabot-comments:
     runs-on: ubuntu-18.04
-    # Operators: https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#operators
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    # Github operators
+    #   Doc: https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#operators
+    # YAML folding operator `>`
+    #   Doc: https://stackoverflow.com/questions/53098493/how-to-nicely-split-on-multiple-lines-long-conditionals-with-or-on-ansible/53099054#53099054
+    if: >
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+      github.actor == 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v2
       - name: Display workflow info


### PR DESCRIPTION
Only allows `dependabot-comments` job triggered on `pull_request` event.

Ref: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/