### PR TITLE
feat: [dependabot write permission] Revert pr 94

### DIFF
--- a/.github/workflows/workflow-run.yml
+++ b/.github/workflows/workflow-run.yml
@@ -48,7 +48,7 @@ jobs:
   # Or [PR #58](https://github.com/marilyn79218/react-lazy-show/pull/58)
   dependabot-comments:
     runs-on: ubuntu-18.04
-    # Github operators
+    # Workflow operators
     #   Doc: https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#operators
     # YAML folding operator `>`
     #   Doc: https://stackoverflow.com/questions/53098493/how-to-nicely-split-on-multiple-lines-long-conditionals-with-or-on-ansible/53099054#53099054

--- a/.github/workflows/workflow-run.yml
+++ b/.github/workflows/workflow-run.yml
@@ -52,8 +52,7 @@ jobs:
     #   Doc: https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#operators
     # YAML folding operator `>`
     #   Doc: https://stackoverflow.com/questions/53098493/how-to-nicely-split-on-multiple-lines-long-conditionals-with-or-on-ansible/53099054#53099054
-    if: >
-      ${{ github.event.workflow_run.event == 'pull_request' && github.actor == 'dependabot[bot]' }}
+    if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v2
       - name: Display workflow info
@@ -63,6 +62,7 @@ jobs:
           echo "PR branch  - ${{ github.event.workflow_run.head_branch }}"
           echo "PR commit - ${{ github.event.workflow_run.head_sha }}"
           echo "Workflow actor - ${{ github.actor }}"
+          echo "Workflow event - ${{ github.event.workflow_run.event }}"
           echo "Workflow status - ${{ github.event.workflow_run.status }}"
           echo "Workflow conclusion - ${{ github.event.workflow_run.conclusion }}"
       # TODO: remove `dawidd6/action-download-artifact@v2` and download artifact by ourself


### PR DESCRIPTION
As shown in screenshot, not only `dependabot` can trigger `workflow_run` since #94, this PR reverts it and also logs `workflow_run.event` to see what's going wrong.

![Screen Shot 2021-07-14 at 4 26 05 PM](https://user-images.githubusercontent.com/22482071/125589761-d6372b48-d01c-453c-956a-7af4bddeeaac.png)
