### PR TITLE
feat: [dependabot write permission] Same line `if` condition check

### DIFF
--- a/.github/workflows/workflow-run.yml
+++ b/.github/workflows/workflow-run.yml
@@ -50,8 +50,6 @@ jobs:
     runs-on: ubuntu-18.04
     # Workflow operators
     #   Doc: https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#operators
-    # YAML folding operator `>`
-    #   Doc: https://stackoverflow.com/questions/53098493/how-to-nicely-split-on-multiple-lines-long-conditionals-with-or-on-ansible/53099054#53099054
     if: ${{ github.event.workflow_run.event == 'pull_request' && github.actor == 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/workflow-run.yml
+++ b/.github/workflows/workflow-run.yml
@@ -52,7 +52,7 @@ jobs:
     #   Doc: https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#operators
     # YAML folding operator `>`
     #   Doc: https://stackoverflow.com/questions/53098493/how-to-nicely-split-on-multiple-lines-long-conditionals-with-or-on-ansible/53099054#53099054
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.actor == 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v2
       - name: Display workflow info


### PR DESCRIPTION
Since both [#94](https://github.com/marilyn79218/react-lazy-show/pull/94/files#diff-791e06a00e373dcb530ab45bfc3ed3f9a576b7e4b6edf75e9aef08fe1251d2faR55-R57) and [#99](https://github.com/marilyn79218/react-lazy-show/pull/99/files#diff-791e06a00e373dcb530ab45bfc3ed3f9a576b7e4b6edf75e9aef08fe1251d2faR56) don't work, but in the [`workflow_run.event` log](https://github.com/marilyn79218/react-lazy-show/pull/100/files#diff-791e06a00e373dcb530ab45bfc3ed3f9a576b7e4b6edf75e9aef08fe1251d2faR65) we can see its value is indeed `"pull_request"`, hence this PR makes it as one line and removes the so-called YAML folding operator.