### PR TITLE
experiment: [Comment matching hash] Write comment in PR

### DIFF
--- a/.github/workflows/dependabot-comments/index.js
+++ b/.github/workflows/dependabot-comments/index.js
@@ -6,19 +6,29 @@ const {
 const COMMENT_ANCHOR = "dependabot_comments";
 
 // Allowing contributor AND dependabot to write comments to a pull request
-module.exports = async (github, context, core, commitHash) => {
+module.exports = async (github, context, core, commitHash, workflowName) => {
   try {
     const firstFileData = readFileFromArtifact("first-data-arctifact");
     const secondFileData = readFileFromArtifact("second-data-arctifact");
     const fileData = firstFileData.concat(secondFileData);
 
-    // In `workflow_run` event, regardless the actor is dependabot or not,
-    // we can't retrieve pr number from `context.issue`
-    // { owner: 'marilyn79218', repo: 'react-lazy-show', number: undefined }
-    // console.log("context issue", context.issue);
+    let prNumber;
+    switch (workflowName) {
+      case "workflow_run": {
+        // In `workflow_run` event, regardless the actor is dependabot or not,
+        // we can't retrieve pr number from `context.issue`
+        // { owner: 'marilyn79218', repo: 'react-lazy-show', number: undefined }
+        // console.log("context issue", context.issue);
 
-    const prInfo = await getPrInfo(github, context, core, commitHash);
-    const prNumber = prInfo.number;
+        const prInfo = await getPrInfo(github, context, core, commitHash);
+        prNumber = prInfo.number;
+        break;
+      }
+      case "pr": {
+        prNumber = context.issue.number;
+        break;
+      }
+    }
 
     console.log("prNumber", prNumber);
     console.log("context", context);

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -84,3 +84,17 @@ jobs:
       - name: Display structure of downloaded files
         run: ls -R
         working-directory: .
+  pr-comment:
+    runs-on: ubuntu-18.04
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    needs: [upload-first-data, upload-second-data]
+    steps:
+      - uses: actions/checkout@v2
+      - name: "Writing comments"
+        uses: actions/github-script@v4
+        with:
+          script: |
+            const path = require('path');
+            const scriptPath = path.resolve('./.github/workflows/dependabot-comments/index.js');
+            const commitHash = '${{ github.event.pull_request.head.sha }}';
+            await require(scriptPath)(github, context, core, commitHash, "pr");

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -90,6 +90,11 @@ jobs:
     needs: [upload-first-data, upload-second-data]
     steps:
       - uses: actions/checkout@v2
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: .
       - name: "Writing comments"
         uses: actions/github-script@v4
         with:

--- a/.github/workflows/workflow-run.yml
+++ b/.github/workflows/workflow-run.yml
@@ -105,4 +105,4 @@ jobs:
             // Ref: https://github.com/actions/github-script/issues/143#issue-893411221
             // Ref: https://github.com/actions/github-script/issues/56#issuecomment-642188313
             const commitHash = '${{ github.event.workflow_run.head_sha }}';
-            await require(scriptPath)(github, context, core, commitHash);
+            await require(scriptPath)(github, context, core, commitHash, "workflow_run");


### PR DESCRIPTION
This PR enables writing comments (includes `commit hash`) in a PR, this is to observe whether the commit hash in the latest comment is equivalent to the commit when it is actaully gets merged.