### PR TITLE
revert: [Download on master] Revert pr 110

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,1 @@
 export const ACTION_NAME = 'REACT_SELECTRONIC_ACTIONS';
-
-export const YO = 'KOKOOOOOO WOW';


### PR DESCRIPTION
Since #110 is a success, let's revert it.

### How to tell it's a success?
As mentioned in #29, in #110 comment we have timestamp `2021-09-01T07:36:19.521Z`. When #110 is merged, we see the timestamp that downloaded is also `2021-09-01T07:36:19.521Z` (screenshot 2).

Which is different from the timestamp `2021-09-01T07:36:42.019Z` in #29. (screenshot 3) 

| source | PR comment | Master workflow | Testing PR (different stamp) |
| ------- | ------------ | ----------------- | ----------- |
| Screenshots | ![Screen Shot 2021-09-01 at 3 43 15 PM](https://user-images.githubusercontent.com/22482071/131632905-2428bcc2-5627-473c-bc96-16a4be8bb0d0.png) | ![Screen Shot 2021-09-01 at 3 42 53 PM](https://user-images.githubusercontent.com/22482071/131632950-b9d4f22d-7367-4c6e-9770-328298fa6ff4.png) | ![Screen Shot 2021-09-01 at 3 48 30 PM](https://user-images.githubusercontent.com/22482071/131633198-0f734c88-4bb1-4d0e-bd4f-95612f9d9e4e.png)


This reverts commit 50eea754d2f8cae690c96004fec02b67fd49b631.