### PR TITLE
Sending comment body to google sheet

### DIFF
--- a/.github/workflows/dependabot-comments/index.js
+++ b/.github/workflows/dependabot-comments/index.js
@@ -72,6 +72,10 @@ module.exports = async (github, context, core, commitHash, workflowName) => {
       "gsheetCommands",
       JSON.stringify([
         {
+          command: "getWorksheet",
+          args: { worksheetTitle: "PR Comments" },
+        },
+        {
           command: "appendData",
           args: {
             data: [

--- a/.github/workflows/dependabot-comments/index.js
+++ b/.github/workflows/dependabot-comments/index.js
@@ -67,6 +67,26 @@ module.exports = async (github, context, core, commitHash, workflowName) => {
         body: commentBody,
       });
     }
+
+    core.setOutput(
+      "gsheetCommands",
+      JSON.stringify([
+        {
+          command: "appendData",
+          args: {
+            data: [
+              [
+                new Date().toISOString(),
+                prNumber,
+                commitHash,
+                commentBody,
+              ],
+            ],
+            minCol: 1,
+          },
+        },
+      ]),
+    );
   } catch (error) {
     core.setFailed(error.message);
   }

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -96,6 +96,7 @@ jobs:
         run: ls -R
         working-directory: .
       - name: "Writing comments"
+        id: writing_comments
         uses: actions/github-script@v4
         with:
           script: |
@@ -103,3 +104,12 @@ jobs:
             const scriptPath = path.resolve('./.github/workflows/dependabot-comments/index.js');
             const commitHash = '${{ github.event.pull_request.head.sha }}';
             await require(scriptPath)(github, context, core, commitHash, "pr");
+      - name: Send data to my google spreadsheet
+        id: update_worksheet
+        uses: jroehl/gsheet.action@v1.0.0
+        with:
+          spreadsheetId: 1X4eMsIMWQHsl_6iYsyU78XASNXVxUJQy1E4FkWRcd0o
+          commands: ${{ steps.writing_comments.outputs.gsheetCommands }}
+        env:
+          GSHEET_CLIENT_EMAIL: ${{ secrets.GSHEET_CLIENT_EMAIL }}
+          GSHEET_PRIVATE_KEY: ${{ secrets.GSHEET_PRIVATE_KEY }}


### PR DESCRIPTION
As title. (PR inspired by [Medium Read](https://levelup.gitconnected.com/handling-access-tokens-for-google-apis-with-react-node-js-tutorial-5ebf94d8f90f))

In my own GCP account under project `wow-2021-05-27-yay`:
1. Create a Service Account and permit it to use the [`jroehl/gsheet.action`](https://github.com/jroehl/gsheet.action) with `GSHEET_CLIENT_EMAIL` and `GSHEET_PRIVATE_KEY` (both are accessible when creating a new Service Account, Screenshot 1) ([Repo secrets](https://github.com/marilyn79218/react-lazy-show/settings/secrets/actions) and [How to](https://github.com/Azure/actions-workflow-samples/blob/master/assets/create-secrets-for-GitHub-workflows.md))
2. Enable [Google Sheet API](https://console.cloud.google.com/apis/library/sheets.googleapis.com?project=wow-2021-05-27-yay) (Screenshot 2)
3. Share the writing permission of the [target sheet](https://docs.google.com/spreadsheets/d/1X4eMsIMWQHsl_6iYsyU78XASNXVxUJQy1E4FkWRcd0o/edit#gid=0) with the Service Account (in this case,[`react-lazy-show-sheet@wow-2021-05-27-yay.iam.gserviceaccount.com`](https://console.cloud.google.com/iam-admin/serviceaccounts/details/108245025959740597605?hl=zh-tw&project=wow-2021-05-27-yay)) (Screenshot 3)

| Screenshots | UI |
| ------------ | --- |
| Screenshot 1 | <img width="912" alt="Screen Shot 2022-01-21 at 5 20 03 PM" src="https://user-images.githubusercontent.com/22482071/150501419-4d102d54-210c-4f3b-bfef-eb70f941c176.png"> |
| Screenshot 2 | ![Screen Shot 2022-01-21 at 5 10 44 PM](https://user-images.githubusercontent.com/22482071/150501463-41b99da3-3fd8-4e2f-915b-44d846440928.png) |
| Screenshot 3 | <img width="1440" alt="Screen Shot 2022-01-21 at 5 32 13 PM" src="https://user-images.githubusercontent.com/22482071/150502911-61f18fb0-8b0e-4181-9cf5-cd08f6209519.png"> |
